### PR TITLE
sub-refs.t - handle likely line number reporting from 5.45.0+

### DIFF
--- a/t/sub-refs.t
+++ b/t/sub-refs.t
@@ -16,6 +16,19 @@ my $stderr = capture_error { system (
     '
 ) };
 ok(
+    $stderr eq # line number changes in perl 5.45.x
+'#   Failed test at -e line 3.
+# +----+-------------------+-------------------+
+# | Elt|Got                |Expected           |
+# +----+-------------------+-------------------+
+# |   0|sub {              |sub {              |
+# |   1|    use warnings;  |    use warnings;  |
+# |   2|    use strict;    |    use strict;    |
+# *   3|    1;             |    2;             *
+# |   4|}                  |}                  |
+# +----+-------------------+-------------------+
+# Looks like you failed 1 test of 1.
+' ||
     $stderr eq  # perl 5.16 onwards
 '#   Failed test at -e line 4.
 # +----+-------------------+-------------------+


### PR DESCRIPTION
Early in the next development cycle of the perl interpreter, an attempt will be made to improve the inaccuracy of line number reporting by warning/error messages and caller(), starting with:

* https://github.com/Perl/perl5/pull/24387 - starting statement in elsif() blocks
* https://github.com/Perl/perl5/pull/24389 - loop condition statements
* https://github.com/Perl/perl5/pull/24396 - mid-statement anon sub declarations

These changes break one test in this module written to match a specific emitted line number.

Since that test already matches two alternative forms of test output, this commit adds a third to match the output if the above PRs make it into tagged perl releases.